### PR TITLE
fix: remove trailing commas in keyword_search migration SQL

### DIFF
--- a/supabase/migrations/20260401180821_keyword_search.sql
+++ b/supabase/migrations/20260401180821_keyword_search.sql
@@ -12,7 +12,7 @@ RETURNS TABLE(
     page_number      INTEGER,
     metadata         JSONB,
     source_title     TEXT,
-    source_url       TEXT,
+    source_url       TEXT
 )
 LANGUAGE sql STABLE
 AS $$
@@ -24,7 +24,7 @@ SELECT
     dc.page_number,
     dc.metadata,
     s.title       AS source_title,
-    s.source_url  AS source_url,
+    s.source_url  AS source_url
 FROM
     document_chunks dc
 LEFT JOIN 


### PR DESCRIPTION
## Summary
- Removes trailing comma after last column in `RETURNS TABLE(...)` block
- Removes trailing comma after last column in `SELECT` clause
- Both caused a `syntax error at or near ")"` when running `npx supabase start`

## Test plan
- [ ] Run `npx supabase start` and confirm migrations apply without errors