### PR TITLE
Feat/ind diff notify

### DIFF
--- a/data_pipeline/diff_detector/classify.py
+++ b/data_pipeline/diff_detector/classify.py
@@ -1,0 +1,126 @@
+"""LLM classifier: maps a PageDiffSummary to affected user profile (attribute, value) pairs."""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from diff_detector.diff import PageDiff
+from diff_detector.summarize import PageDiffSummary
+from lib.env import load_pipeline_env
+from lib.user_attributes import USER_PROFILE_ATTRIBUTES
+
+IND_DIFF_CLASSIFY_MODEL = os.getenv("IND_DIFF_CLASSIFY_MODEL", "gpt-4o-mini")
+
+# Pre-rendered once for inclusion in the prompt
+_ATTRIBUTES_JSON = json.dumps(USER_PROFILE_ATTRIBUTES, indent=2, ensure_ascii=False)
+
+RelevanceMap = dict[str, dict[str | bool, list[str]]]
+
+SYSTEM_PROMPT = """
+You are a relevance classifier for an expat assistant in the Netherlands.
+
+You will be given a summary of changes to an IND (Immigration and Naturalisation
+Service) web page, and a dictionary of user profile attributes with their possible
+values.
+
+Your job is to decide which (attribute, value) pairs are affected by these changes.
+Only include pairs where the change is genuinely relevant to a user with that value.
+If a change affects all users regardless of profile, include all applicable values.
+If a change is irrelevant to a particular group, exclude them.
+
+Return only attribute keys and values from the provided dictionary — do not invent new ones.
+""".strip()
+
+HUMAN_TEMPLATE = """\
+Page URL: {url}
+Change type: {change_type}
+
+Summary of changes:
+{bullets}
+
+User profile attributes and allowed values:
+{attributes}
+"""
+
+CLASSIFY_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", SYSTEM_PROMPT),
+        ("human", HUMAN_TEMPLATE),
+    ]
+)
+
+
+class PageRelevance(BaseModel):
+    affected: dict[str, list[str | bool]] = Field(
+        description=(
+            "For each relevant attribute, the list of values affected by this change. "
+            "Only include attributes and values from the provided dictionary."
+        )
+    )
+
+
+@lru_cache(maxsize=1)
+def _get_classify_chain():
+    load_pipeline_env()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY must be set before classifying relevance.")
+
+    llm = ChatOpenAI(
+        model=IND_DIFF_CLASSIFY_MODEL,
+        temperature=0,
+        api_key=api_key,
+    )
+    return CLASSIFY_PROMPT | llm.with_structured_output(PageRelevance, method="function_calling")
+
+
+def classify_page_relevance(diff: PageDiff, summary: PageDiffSummary) -> PageRelevance:
+    """Classify which (attribute, value) pairs are affected by a page change."""
+    return _get_classify_chain().invoke(
+        {
+            "url": diff.url,
+            "change_type": diff.change_type,
+            # TODO: classify per bullet instead of per page for more precise relevance matching.
+            "bullets": "\n".join(f"- {b}" for b in summary.bullets),
+            "attributes": _ATTRIBUTES_JSON,
+        }
+    )
+
+
+def build_relevance_map(
+    summaries: list[tuple[PageDiff, PageDiffSummary]],
+) -> RelevanceMap:
+    """Build the full relevance map from a list of summarized page diffs.
+
+    Returns dict[attribute, dict[value, list[bullet_strings]]].
+    All (attribute, value) pairs are initialised — empty list means no relevant changes.
+    """
+    relevance_map: RelevanceMap = {
+        attribute: {value: [] for value in values}
+        for attribute, values in USER_PROFILE_ATTRIBUTES.items()
+    }
+
+    for index, (diff, summary) in enumerate(summaries, start=1):
+        relevance = classify_page_relevance(diff, summary)
+        for attribute, affected_values in relevance.affected.items():
+            if attribute not in relevance_map:
+                continue
+            for value in affected_values:
+                if value not in relevance_map[attribute]:
+                    continue
+                # TODO: classify per bullet instead of per page so each bullet
+                # only lands in the slots it's relevant to, avoiding duplication
+                # across multiple affected values.
+                relevance_map[attribute][value].extend(summary.bullets)
+        print(
+            f"  Classified {index}/{len(summaries)} ({diff.change_type}): "
+            f"{diff.url} — affects {sum(len(v) for v in relevance.affected.values())} value(s)"
+        )
+
+    return relevance_map

--- a/data_pipeline/diff_detector/diff.py
+++ b/data_pipeline/diff_detector/diff.py
@@ -6,8 +6,10 @@ import argparse
 import difflib
 import json
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 _pipeline_root = Path(__file__).resolve().parents[1]
 if str(_pipeline_root) not in sys.path:
@@ -15,6 +17,14 @@ if str(_pipeline_root) not in sys.path:
 
 from lib.config import DIFF_DIR, SNAPSHOT_DIR
 from lib.supabase_client import get_supabase_client
+
+
+@dataclass(slots=True)
+class PageDiff:
+    url: str
+    change_type: Literal["CHANGED", "ADDED", "REMOVED"]
+    unified_diff: str  # non-empty for CHANGED; empty string otherwise
+    content: str       # new content for CHANGED/ADDED; old content for REMOVED
 
 
 def load_corpus() -> dict[str, str]:
@@ -61,12 +71,10 @@ def load_snapshot(path: Path | None = None) -> dict[str, str]:
     return {r["url"]: r["content"] for r in records if r.get("content")}
 
 
-def run_diff(corpus: dict[str, str], snapshot: dict[str, str]) -> str:
-    """Compare corpus and snapshot, classify pages, and return the full report as a string."""
+def run_diff(corpus: dict[str, str], snapshot: dict[str, str]) -> list[PageDiff]:
+    """Compare corpus and snapshot and return a structured list of page-level changes."""
     all_urls = sorted(set(corpus) | set(snapshot))
-    sections: list[str] = []
-
-    changed = added = removed = unchanged = 0
+    diffs: list[PageDiff] = []
 
     for url in all_urls:
         in_corpus = url in corpus
@@ -75,23 +83,52 @@ def run_diff(corpus: dict[str, str], snapshot: dict[str, str]) -> str:
         if in_corpus and in_snapshot:
             old_lines = corpus[url].splitlines(keepends=True)
             new_lines = snapshot[url].splitlines(keepends=True)
-            diff = list(difflib.unified_diff(old_lines, new_lines, fromfile="corpus", tofile="snapshot"))
-            if diff:
-                sections.append(f"=== CHANGED: {url} ===\n" + "".join(diff))
-                changed += 1
-            else:
-                unchanged += 1
+            diff_lines = list(
+                difflib.unified_diff(old_lines, new_lines, fromfile="corpus", tofile="snapshot")
+            )
+            if diff_lines:
+                diffs.append(PageDiff(
+                    url=url,
+                    change_type="CHANGED",
+                    unified_diff="".join(diff_lines),
+                    content=snapshot[url],
+                ))
         elif in_snapshot:
-            sections.append(f"=== ADDED: {url} ===")
-            added += 1
+            new_lines = snapshot[url].splitlines(keepends=True)
+            diffs.append(PageDiff(
+                url=url,
+                change_type="ADDED",
+                unified_diff="".join(f"+{line}" for line in new_lines),
+                content=snapshot[url],
+            ))
         else:
-            sections.append(f"=== REMOVED: {url} ===")
-            removed += 1
+            old_lines = corpus[url].splitlines(keepends=True)
+            diffs.append(PageDiff(
+                url=url,
+                change_type="REMOVED",
+                unified_diff="".join(f"-{line}" for line in old_lines),
+                content=corpus[url],
+            ))
+
+    return diffs
+
+
+def render_report(diffs: list[PageDiff], total_pages: int) -> str:
+    """Render a human-readable diff report. Only CHANGED pages are shown in the body."""
+    changed = sum(1 for d in diffs if d.change_type == "CHANGED")
+    added = sum(1 for d in diffs if d.change_type == "ADDED")
+    removed = sum(1 for d in diffs if d.change_type == "REMOVED")
+    unchanged = total_pages - len(diffs)
 
     summary = (
         f"Summary: {changed} changed, {added} added, {removed} removed, {unchanged} unchanged "
-        f"({len(all_urls)} total pages)\n"
+        f"({total_pages} total pages)\n"
     )
+    sections = [
+        f"=== CHANGED: {d.url} ===\n{d.unified_diff}"
+        for d in diffs
+        if d.change_type == "CHANGED"
+    ]
     return summary + "\n" + "\n\n".join(sections)
 
 
@@ -118,8 +155,10 @@ def main() -> None:
     args = parser.parse_args()
 
     corpus = load_corpus()
-    snapshot = load_snapshot(args.snapshot)
-    report = run_diff(corpus, snapshot)
+    snapshot_data = load_snapshot(args.snapshot)
+    total_pages = len(set(corpus) | set(snapshot_data))
+    diffs = run_diff(corpus, snapshot_data)
+    report = render_report(diffs, total_pages)
     write_report(report)
 
 

--- a/data_pipeline/diff_detector/notify.py
+++ b/data_pipeline/diff_detector/notify.py
@@ -1,0 +1,177 @@
+"""Email rendering for IND diff notifications.
+
+Sending and user querying are NOT here — those depend on the ind_diff_email_enabled
+DB migration (in a separate branch). Once that lands, wire up:
+  - TODO: query Supabase for users where ind_diff_email_enabled = TRUE
+  - TODO: for each user call render_ind_diff_email and send via email_client.py
+"""
+
+from __future__ import annotations
+
+from diff_detector.classify import RelevanceMap
+from lib.user_attributes import USER_PROFILE_ATTRIBUTES
+
+_BOOL_SECTION_HEADERS: dict[str, dict[bool, str]] = {
+    "has_fiscal_partner": {True: "someone with a fiscal partner", False: "someone without a fiscal partner"},
+    "age_bracket_under_30": {True: "someone under 30", False: "someone 30 or older"},
+    "prior_nl_residency": {True: "someone who previously lived in the Netherlands", False: "someone without prior NL residency"},
+}
+
+
+def _resolve_value_label(attribute: str, value: str | bool) -> str:
+    """Return a display label for a profile value (never prints True/False)."""
+    if isinstance(value, bool):
+        return _BOOL_SECTION_HEADERS.get(attribute, {}).get(value, str(value))
+    return str(value)
+
+
+def get_user_bullets(user: dict, relevance_map: RelevanceMap) -> dict[str, list[str]]:
+    """Return {value_label: [bullets]} for every attribute where this user has relevant changes.
+
+    Keys are human-readable value labels (e.g. "Highly Skilled Migrant", "someone under 30").
+    Bullets that appear in more than one slot are only kept in the first one to avoid repetition.
+    """
+    result: dict[str, list[str]] = {}
+    seen: set[str] = set()
+
+    for attribute in USER_PROFILE_ATTRIBUTES:
+        user_value = user.get(attribute)
+        if user_value is None:
+            continue
+        slot = relevance_map.get(attribute, {}).get(user_value, [])
+        fresh = [b for b in slot if b not in seen]
+        if fresh:
+            result[_resolve_value_label(attribute, user_value)] = fresh
+            seen.update(fresh)
+
+    return result
+
+
+def render_ind_diff_email(
+    user: dict, relevance_map: RelevanceMap
+) -> tuple[str, str, str] | None:
+    """Render a personalised IND diff notification email for one user.
+
+    Returns (subject, plain_text, html) or None if no changes are relevant to this user
+    (so callers can skip sending entirely).
+    """
+    sections = get_user_bullets(user, relevance_map)
+    if not sections:
+        return None
+
+    subject = "IND update: immigration policy changes relevant to you"
+
+    # --- Plain text ---
+    lines: list[str] = [
+        "IND POLICY UPDATE",
+        "",
+        "We detected changes to the IND (Dutch Immigration and Naturalisation Service)",
+        "website that may be relevant to your profile.",
+        "",
+    ]
+    for value_label, bullets in sections.items():
+        lines.append(f"As {value_label}:")
+        for bullet in bullets:
+            lines.append(f"  • {bullet}")
+        lines.append("")
+    # lines += [
+    #     "—",
+    #     "You're receiving this because you opted in to IND policy update notifications.",
+    #     "Visit https://patty.nl to update your preferences.",
+    # ]
+    plain_text = "\n".join(lines)
+
+    # --- HTML ---
+    sections_html_parts: list[str] = []
+    for value_label, bullets in sections.items():
+        # TODO: "As €60,000 - €80,000" reads awkwardly — consider per-attribute header templates
+        header = f"As {value_label}"
+        bullet_items = "\n".join(f"            <li>{b}</li>" for b in bullets)
+        sections_html_parts.append(
+            f'        <div class="section">\n'
+            f"          <h3>{header}</h3>\n"
+            f"          <ul>\n"
+            f"{bullet_items}\n"
+            f"          </ul>\n"
+            f"        </div>"
+        )
+    sections_html = "\n".join(sections_html_parts)
+
+    html = f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IND Policy Update</title>
+  <style>
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #1a1a1a;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 24px 16px;
+      background: #f4f4f5;
+    }}
+    .card {{
+      background: white;
+      border-radius: 10px;
+      overflow: hidden;
+      box-shadow: 0 1px 4px rgba(0,0,0,.08);
+    }}
+    .header {{
+      background: #003082;
+      color: white;
+      padding: 24px 28px;
+    }}
+    .header h1 {{ margin: 0; font-size: 20px; font-weight: 700; }}
+    .header p {{ margin: 6px 0 0; font-size: 13px; opacity: .8; }}
+    .body {{ padding: 24px 28px; }}
+    .intro {{ margin: 0 0 20px; color: #444; line-height: 1.6; }}
+    .section {{
+      border: 1px solid #e8e8ea;
+      border-radius: 7px;
+      padding: 16px 18px;
+      margin-bottom: 14px;
+    }}
+    .section h3 {{
+      margin: 0 0 10px;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .6px;
+      color: #003082;
+    }}
+    .section ul {{ margin: 0; padding-left: 18px; }}
+    .section li {{ margin-bottom: 6px; line-height: 1.55; color: #333; }}
+    .footer {{
+      font-size: 12px;
+      color: #999;
+      text-align: center;
+      padding: 18px 28px;
+      border-top: 1px solid #f0f0f0;
+    }}
+    .footer a {{ color: #003082; text-decoration: none; }}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="header">
+      <h1>IND Policy Update</h1>
+      <p>Changes to Dutch immigration rules relevant to your profile</p>
+    </div>
+    <div class="body">
+      <p class="intro">
+        We detected changes to the IND website. Here&rsquo;s what may affect you:
+      </p>
+{sections_html}
+    </div>
+    <div class="footer">
+      You&rsquo;re receiving this because you opted in to IND policy update notifications.<br>
+      <a href="https://patty.nl">Visit Patty</a> to manage your preferences.
+    </div>
+  </div>
+</body>
+</html>"""
+
+    return subject, plain_text, html

--- a/data_pipeline/diff_detector/summarize.py
+++ b/data_pipeline/diff_detector/summarize.py
@@ -1,0 +1,120 @@
+"""LLM summarizer for IND page diffs."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Literal
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from diff_detector.diff import PageDiff
+from lib.env import load_pipeline_env
+
+
+IND_DIFF_SUMMARY_MODEL = os.getenv("IND_DIFF_SUMMARY_MODEL", "gpt-4o-mini")
+
+CHANGE_TYPE_INSTRUCTIONS: dict[str, str] = {
+    "CHANGED": (
+        "The page content has been modified. "
+        "For each distinct semantic change you identify, write one bullet point "
+        "in the form 'Before: <old state>. Now: <new state>.' "
+        "Group related line changes into a single bullet — do not produce one "
+        "bullet per diff line."
+    ),
+    "ADDED": (
+        "This is a brand new page that did not exist before. "
+        "Summarize what this page introduces: what requirement, option, right, "
+        "or constraint now exists that did not before. "
+        "Frame each bullet as 'This page introduces: <topic>.'"
+    ),
+    "REMOVED": (
+        "This page has been removed entirely. "
+        "Summarize what it covered: what requirement, option, right, or "
+        "constraint no longer applies. "
+        "Frame each bullet as 'This no longer applies: <topic>.'"
+    ),
+}
+
+SYSTEM_PROMPT = """
+You are a policy analyst summarizing changes to the Dutch IND (Immigration and
+Naturalisation Service) website for expats and international residents in the
+Netherlands.
+
+You will be given the URL of a page and a diff showing what changed.
+Lines starting with '+' are new content. Lines starting with '-' are removed content.
+Lines with neither prefix are unchanged context.
+
+Your job:
+- Identify every distinct semantic change in the diff.
+- Write one concise bullet point per semantic change following the instructions
+  provided for the change type.
+- Be factual and specific — include concrete values, deadlines, or conditions
+  mentioned in the diff.
+- Do not invent information not present in the diff.
+- Do not comment on formatting, whitespace, or punctuation changes.
+""".strip()
+
+HUMAN_TEMPLATE = """\
+URL: {url}
+Change type: {change_type}
+Instructions: {instructions}
+
+Diff:
+{unified_diff}
+"""
+
+SUMMARIZE_PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", SYSTEM_PROMPT),
+        ("human", HUMAN_TEMPLATE),
+    ]
+)
+
+
+class PageDiffSummary(BaseModel):
+    bullets: list[str] = Field(
+        description="One bullet point per distinct semantic change."
+    )
+
+
+@lru_cache(maxsize=1)
+def _get_summarize_chain():
+    load_pipeline_env()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY must be set before summarizing diffs.")
+
+    llm = ChatOpenAI(
+        model=IND_DIFF_SUMMARY_MODEL,
+        temperature=0,
+        api_key=api_key,
+    )
+    return SUMMARIZE_PROMPT | llm.with_structured_output(PageDiffSummary)
+
+
+def summarize_page_diff(diff: PageDiff) -> PageDiffSummary:
+    """Summarize a single PageDiff into bullet points using an LLM."""
+    return _get_summarize_chain().invoke(
+        {
+            "url": diff.url,
+            "change_type": diff.change_type,
+            "instructions": CHANGE_TYPE_INSTRUCTIONS[diff.change_type],
+            "unified_diff": diff.unified_diff,
+        }
+    )
+
+
+def summarize_page_diffs(diffs: list[PageDiff]) -> list[tuple[PageDiff, PageDiffSummary]]:
+    """Summarize a batch of PageDiffs."""
+    results: list[tuple[PageDiff, PageDiffSummary]] = []
+    for index, diff in enumerate(diffs, start=1):
+        summary = summarize_page_diff(diff)
+        results.append((diff, summary))
+        print(
+            f"  Summarized {index}/{len(diffs)} ({diff.change_type}): "
+            f"{diff.url} — {len(summary.bullets)} bullet(s)"
+        )
+    return results

--- a/data_pipeline/lib/user_attributes.py
+++ b/data_pipeline/lib/user_attributes.py
@@ -1,0 +1,45 @@
+"""Single source of truth for user profile attributes and their allowed values."""
+
+USER_PROFILE_ATTRIBUTES: dict[str, list[str | bool]] = {
+    "nationality": [
+        "EU/EEA citizen",
+        "Non-EU national",
+        "British (post-Brexit)",
+        "Dutch citizen",
+    ],
+    "purpose_of_stay": [
+        "Employed by Dutch/EU company",
+        "Highly Skilled Migrant",
+        "Self-employed / ZZP",
+        "Study",
+        "Family reunification",
+        "Starting a startup",
+        "Other",
+    ],
+    "employment_status": [
+        "Employed full-time",
+        "Employed part-time",
+        "Self-employed / ZZP",
+        "DGA (director/shareholder of own BV)",
+        "Not working / dependent on partner",
+        "Student",
+    ],
+    "registration_status": [
+        "Not yet arrived in the Netherlands",
+        "Arrived, not yet registered",
+        "BRP registered at a municipality",
+        "Have a BSN number",
+        "Have DigiD",
+    ],
+    "salary_band": [
+        "Under €20,000",
+        "€20,000 - €40,000",
+        "€40,000 - €60,000",
+        "€60,000 - €80,000",
+        "€80,000 - €100,000",
+        "Over €100,000",
+    ],
+    "has_fiscal_partner": [True, False],
+    "age_bracket_under_30": [True, False],
+    "prior_nl_residency": [True, False],
+}

--- a/data_pipeline/tests/test_diff.py
+++ b/data_pipeline/tests/test_diff.py
@@ -1,36 +1,47 @@
-from diff_detector.diff import run_diff
+from diff_detector.diff import PageDiff, render_report, run_diff
 
 
-def test_unchanged_page_excluded_from_report():
+def test_unchanged_page_produces_no_diff():
     corpus = {"https://ind.nl/page-a": "Same content"}
     snapshot = {"https://ind.nl/page-a": "Same content"}
-    report = run_diff(corpus, snapshot)
-    assert "UNCHANGED" not in report
-    assert "page-a" not in report
-    assert "1 unchanged" in report
+    diffs = run_diff(corpus, snapshot)
+    assert diffs == []
 
 
-def test_changed_page_shows_unified_diff():
+def test_changed_page_has_unified_diff_and_new_content():
     corpus = {"https://ind.nl/page-a": "old line\n"}
     snapshot = {"https://ind.nl/page-a": "new line\n"}
-    report = run_diff(corpus, snapshot)
-    assert "CHANGED: https://ind.nl/page-a" in report
-    assert "-old line" in report
-    assert "+new line" in report
+    diffs = run_diff(corpus, snapshot)
+    assert len(diffs) == 1
+    assert diffs[0].change_type == "CHANGED"
+    assert diffs[0].url == "https://ind.nl/page-a"
+    assert "-old line" in diffs[0].unified_diff
+    assert "+new line" in diffs[0].unified_diff
+    assert diffs[0].content == "new line\n"
 
 
-def test_added_page():
+def test_added_page_has_full_new_content():
     corpus = {}
     snapshot = {"https://ind.nl/new-page": "Some content"}
-    report = run_diff(corpus, snapshot)
-    assert "ADDED: https://ind.nl/new-page" in report
+    diffs = run_diff(corpus, snapshot)
+    assert len(diffs) == 1
+    assert diffs[0].change_type == "ADDED"
+    assert diffs[0].url == "https://ind.nl/new-page"
+    assert diffs[0].content == "Some content"
+    assert "+Some content" in diffs[0].unified_diff
+    assert "-" not in diffs[0].unified_diff
 
 
-def test_removed_page():
+def test_removed_page_has_full_old_content():
     corpus = {"https://ind.nl/old-page": "Some content"}
     snapshot = {}
-    report = run_diff(corpus, snapshot)
-    assert "REMOVED: https://ind.nl/old-page" in report
+    diffs = run_diff(corpus, snapshot)
+    assert len(diffs) == 1
+    assert diffs[0].change_type == "REMOVED"
+    assert diffs[0].url == "https://ind.nl/old-page"
+    assert diffs[0].content == "Some content"
+    assert "-Some content" in diffs[0].unified_diff
+    assert "+" not in diffs[0].unified_diff
 
 
 def test_summary_counts_are_correct():
@@ -44,8 +55,27 @@ def test_summary_counts_are_correct():
         "https://ind.nl/unchanged": "same\n",
         "https://ind.nl/added": "fresh\n",
     }
-    report = run_diff(corpus, snapshot)
+    total = len(set(corpus) | set(snapshot))
+    diffs = run_diff(corpus, snapshot)
+    report = render_report(diffs, total)
     assert "1 changed" in report
     assert "1 added" in report
     assert "1 removed" in report
     assert "1 unchanged" in report
+
+
+def test_report_body_contains_only_changed_pages():
+    corpus = {
+        "https://ind.nl/changed": "old\n",
+        "https://ind.nl/removed": "gone\n",
+    }
+    snapshot = {
+        "https://ind.nl/changed": "new\n",
+        "https://ind.nl/added": "fresh\n",
+    }
+    total = len(set(corpus) | set(snapshot))
+    diffs = run_diff(corpus, snapshot)
+    report = render_report(diffs, total)
+    assert "CHANGED: https://ind.nl/changed" in report
+    assert "ADDED" not in report
+    assert "REMOVED" not in report

--- a/data_pipeline/tests/test_ind_classify_integration.py
+++ b/data_pipeline/tests/test_ind_classify_integration.py
@@ -1,0 +1,56 @@
+"""
+Integration test: run the full summarize → classify → build_relevance_map pipeline
+on a real IND diff and assert the resulting map makes sense.
+
+Uses the sponsor recognition page diff (50→65 points, 4→3 year penalty window),
+which is clearly relevant to HSM-related users and not to students.
+
+Run with:
+    uv run --package data-pipeline pytest -m integration data_pipeline/tests/test_ind_classify_integration.py -v -s
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from diff_detector.classify import build_relevance_map
+from diff_detector.diff import run_diff
+from diff_detector.summarize import summarize_page_diffs
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+SPONSOR_URL = "https://ind.nl/en/residence-permits/work/apply-for-recognition-as-sponsor"
+
+
+def _load_fixture(name: str) -> dict[str, str]:
+    return {
+        r["url"]: r["content"]
+        for r in json.loads((FIXTURES / name).read_text())
+        if r.get("content")
+    }
+
+
+@pytest.fixture(scope="module")
+def relevance_map():
+    baseline = _load_fixture("ind_snapshot_baseline.json")
+    modified = _load_fixture("ind_snapshot_modified.json")
+
+    # Only test the sponsor page to keep the test focused
+    sponsor_diff = next(d for d in run_diff(baseline, modified) if d.url == SPONSOR_URL)
+    summaries = summarize_page_diffs([sponsor_diff])
+    return build_relevance_map(summaries)
+
+
+@pytest.mark.integration
+def test_hsm_slot_is_populated(relevance_map):
+    """The sponsor recognition page is about HSM employer criteria — HSM users must be notified."""
+    bullets = relevance_map["purpose_of_stay"]["Highly Skilled Migrant"]
+    assert bullets, "Expected bullets for Highly Skilled Migrant"
+    combined = " ".join(bullets)
+    assert "65" in combined or "50" in combined, "Expected point threshold values in bullets"
+
+
+@pytest.mark.integration
+def test_study_slot_is_empty(relevance_map):
+    """Sponsor recognition rules have nothing to do with students."""
+    assert relevance_map["purpose_of_stay"]["Study"] == []

--- a/data_pipeline/tests/test_ind_diff.py
+++ b/data_pipeline/tests/test_ind_diff.py
@@ -1,22 +1,58 @@
 import json
 from pathlib import Path
 
-from diff_detector.diff import run_diff
+from diff_detector.diff import render_report, run_diff
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def test_ind_diff_matches_golden():
-    baseline = {
+def _load_fixture(name: str) -> dict[str, str]:
+    return {
         r["url"]: r["content"]
-        for r in json.loads((FIXTURES / "ind_snapshot_baseline.json").read_text())
-        if r.get("content")
-    }
-    modified = {
-        r["url"]: r["content"]
-        for r in json.loads((FIXTURES / "ind_snapshot_modified.json").read_text())
+        for r in json.loads((FIXTURES / name).read_text())
         if r.get("content")
     }
 
+
+def test_ind_diff_matches_golden():
+    baseline = _load_fixture("ind_snapshot_baseline.json")
+    modified = _load_fixture("ind_snapshot_modified.json")
+    total = len(set(baseline) | set(modified))
+
     expected = (FIXTURES / "ind_diff_expected.txt").read_text()
-    assert run_diff(baseline, modified) == expected
+    assert render_report(run_diff(baseline, modified), total) == expected
+
+
+def test_added_and_removed_pages_carry_content_but_not_in_report():
+    baseline = _load_fixture("ind_snapshot_baseline.json")
+    modified = _load_fixture("ind_snapshot_modified.json")
+
+    added_url = "https://ind.nl/en/new-policy-page"
+    added_content = "This is a brand new IND policy page about something important."
+    removed_url = next(iter(baseline))  # pick the first real baseline page as the removed one
+    removed_content = baseline[removed_url]
+
+    # REMOVED = in corpus (baseline) but absent from snapshot (modified)
+    # ADDED   = absent from corpus but present in snapshot
+    corpus = baseline
+    snapshot = {url: c for url, c in modified.items() if url != removed_url}
+    snapshot[added_url] = added_content
+
+    total = len(set(corpus) | set(snapshot))
+    diffs = run_diff(corpus, snapshot)
+    report = render_report(diffs, total)
+
+    added = next(d for d in diffs if d.change_type == "ADDED")
+    assert added.url == added_url
+    assert added.content == added_content
+    assert all(line.startswith("+") for line in added.unified_diff.splitlines())
+
+    removed = next(d for d in diffs if d.change_type == "REMOVED")
+    assert removed.url == removed_url
+    assert removed.content == removed_content
+    assert all(line.startswith("-") for line in removed.unified_diff.splitlines())
+
+    assert "ADDED" not in report
+    assert "REMOVED" not in report
+    assert added_url not in report
+    assert removed_url not in report

--- a/data_pipeline/tests/test_ind_diff_db.py
+++ b/data_pipeline/tests/test_ind_diff_db.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from diff_detector.diff import load_corpus, run_diff
+from diff_detector.diff import load_corpus, render_report, run_diff
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -31,5 +31,6 @@ def test_ind_diff_db_matches_golden():
         if r.get("content")
     }
 
+    total = len(set(corpus) | set(snapshot))
     expected = (FIXTURES / "ind_diff_db_expected.txt").read_text()
-    assert run_diff(corpus, snapshot) == expected
+    assert render_report(run_diff(corpus, snapshot), total) == expected

--- a/data_pipeline/tests/test_ind_notify.py
+++ b/data_pipeline/tests/test_ind_notify.py
@@ -1,0 +1,168 @@
+"""Unit tests for diff_detector/notify.py.
+
+All tests use a hand-crafted relevance map — no LLM calls needed.
+
+To visually inspect the rendered email output, run:
+    uv run --package data-pipeline pytest data_pipeline/tests/test_ind_notify.py -v -s -k preview
+"""
+
+from diff_detector.notify import get_user_bullets, render_ind_diff_email
+
+BULLET_A = "The RVO point threshold for sponsors increased from 50 to 65."
+BULLET_B = "The penalty lookback window decreased from 4 to 3 years."
+BULLET_C = "Short-term researcher mobility window changed from 180 to 120 days."
+
+# A minimal relevance map with two populated slots
+RELEVANCE_MAP = {
+    "nationality": {
+        "EU/EEA citizen": [],
+        "Non-EU national": [],
+        "British (post-Brexit)": [],
+        "Dutch citizen": [],
+    },
+    "purpose_of_stay": {
+        "Employed by Dutch/EU company": [],
+        "Highly Skilled Migrant": [BULLET_A, BULLET_B],
+        "Self-employed / ZZP": [],
+        "Study": [],
+        "Family reunification": [],
+        "Starting a startup": [],
+        "Other": [],
+    },
+    "employment_status": {
+        "Employed full-time": [],
+        "Employed part-time": [],
+        "Self-employed / ZZP": [],
+        "DGA (director/shareholder of own BV)": [],
+        "Not working / dependent on partner": [],
+        "Student": [],
+    },
+    "registration_status": {
+        "Not yet arrived in the Netherlands": [],
+        "Arrived, not yet registered": [],
+        "BRP registered at a municipality": [],
+        "Have a BSN number": [],
+        "Have DigiD": [],
+    },
+    "salary_band": {
+        "Under €20,000": [],
+        "€20,000 - €40,000": [],
+        "€40,000 - €60,000": [],
+        "€60,000 - €80,000": [BULLET_C],
+        "€80,000 - €100,000": [],
+        "Over €100,000": [],
+    },
+    "has_fiscal_partner": {True: [], False: []},
+    "age_bracket_under_30": {True: [], False: []},
+    "prior_nl_residency": {True: [], False: []},
+}
+
+HSM_USER = {
+    "purpose_of_stay": "Highly Skilled Migrant",
+    "nationality": "Non-EU national",
+    "employment_status": "Employed full-time",
+    "salary_band": "€60,000 - €80,000",
+    "has_fiscal_partner": False,
+    "age_bracket_under_30": False,
+    "prior_nl_residency": False,
+}
+
+STUDENT_USER = {
+    "purpose_of_stay": "Study",
+    "nationality": "EU/EEA citizen",
+    "employment_status": "Student",
+    "has_fiscal_partner": False,
+    "age_bracket_under_30": True,
+    "prior_nl_residency": False,
+}
+
+
+class TestGetUserBullets:
+    def test_hsm_user_gets_sponsor_bullets(self):
+        bullets = get_user_bullets(HSM_USER, RELEVANCE_MAP)
+        assert "Highly Skilled Migrant" in bullets
+        assert BULLET_A in bullets["Highly Skilled Migrant"]
+        assert BULLET_B in bullets["Highly Skilled Migrant"]
+
+    def test_student_user_gets_no_bullets(self):
+        bullets = get_user_bullets(STUDENT_USER, RELEVANCE_MAP)
+        assert bullets == {}
+
+    def test_duplicate_bullets_not_repeated(self):
+        map_with_overlap = {
+            **RELEVANCE_MAP,
+            "salary_band": {
+                **RELEVANCE_MAP["salary_band"],
+                "€60,000 - €80,000": [BULLET_A],  # same bullet as purpose_of_stay HSM slot
+            },
+        }
+        bullets = get_user_bullets(HSM_USER, map_with_overlap)
+        all_bullets = [b for section in bullets.values() for b in section]
+        assert all_bullets.count(BULLET_A) == 1, "Duplicate bullet should appear only once"
+
+    def test_missing_attribute_in_user_is_skipped(self):
+        partial_user = {"purpose_of_stay": "Highly Skilled Migrant"}
+        bullets = get_user_bullets(partial_user, RELEVANCE_MAP)
+        assert "Highly Skilled Migrant" in bullets
+        assert len(bullets) == 1
+
+
+class TestRenderIndDiffEmail:
+    def test_returns_none_for_irrelevant_user(self):
+        assert render_ind_diff_email(STUDENT_USER, RELEVANCE_MAP) is None
+
+    def test_returns_three_tuple_for_relevant_user(self):
+        result = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        assert result is not None
+        subject, plain_text, html = result
+        assert isinstance(subject, str) and subject
+        assert isinstance(plain_text, str) and plain_text
+        assert isinstance(html, str) and html
+
+    def test_subject_mentions_ind(self):
+        subject, _, _ = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        assert "IND" in subject
+
+    def test_plain_text_contains_bullets(self):
+        _, plain_text, _ = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        assert BULLET_A in plain_text
+        assert BULLET_B in plain_text
+
+    def test_html_contains_bullets(self):
+        _, _, html = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        assert BULLET_A in html
+        assert BULLET_B in html
+
+    def test_html_is_valid_document(self):
+        _, _, html = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        assert html.startswith("<!DOCTYPE html>")
+        assert "</html>" in html
+
+    def test_boolean_attribute_renders_human_label(self):
+        user_with_partner = {**HSM_USER, "has_fiscal_partner": True}
+        map_with_partner_bullet = {
+            **RELEVANCE_MAP,
+            "has_fiscal_partner": {True: ["New tax benefit for fiscal partners."], False: []},
+        }
+        _, plain_text, html = render_ind_diff_email(user_with_partner, map_with_partner_bullet)
+        assert "True" not in plain_text
+        assert "True" not in html
+        assert "fiscal partner" in plain_text
+        assert "fiscal partner" in html
+
+
+class TestEmailPreview:
+    """Not real assertions — just print the rendered output for visual inspection.
+
+    Run with:
+        uv run --package data-pipeline pytest data_pipeline/tests/test_ind_notify.py -v -s -k preview
+    """
+
+    def test_preview_hsm_user(self):
+        subject, plain_text, _ = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        print(f"\nSubject: {subject}\n")
+        print(plain_text)
+
+    def test_preview_hsm_user_html(self):
+        _, _, html = render_ind_diff_email(HSM_USER, RELEVANCE_MAP)
+        print(html)

--- a/data_pipeline/tests/test_ind_summarize.py
+++ b/data_pipeline/tests/test_ind_summarize.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from diff_detector.diff import PageDiff
+from diff_detector.summarize import PageDiffSummary, summarize_page_diff, summarize_page_diffs
+
+
+def make_diff(change_type, unified_diff="+ some content"):
+    return PageDiff(
+        url="https://ind.nl/en/some-page",
+        change_type=change_type,
+        unified_diff=unified_diff,
+        content="some content",
+    )
+
+
+def mock_summary(bullets):
+    return PageDiffSummary(bullets=bullets)
+
+
+@pytest.fixture(autouse=True)
+def patch_chain(monkeypatch):
+    chain = MagicMock()
+    monkeypatch.setattr("diff_detector.summarize._get_summarize_chain", lambda: chain)
+    return chain
+
+
+def test_summarize_changed_returns_bullets(patch_chain):
+    patch_chain.invoke.return_value = mock_summary(["Before: 50 points. Now: 65 points."])
+    diff = make_diff("CHANGED", "-need 50 points\n+need 65 points\n")
+
+    result = summarize_page_diff(diff)
+
+    assert result.bullets == ["Before: 50 points. Now: 65 points."]
+    call_kwargs = patch_chain.invoke.call_args[0][0]
+    assert call_kwargs["change_type"] == "CHANGED"
+    assert call_kwargs["unified_diff"] == diff.unified_diff
+    assert "Before:" in call_kwargs["instructions"]
+
+
+def test_summarize_added_uses_added_instructions(patch_chain):
+    patch_chain.invoke.return_value = mock_summary(["This page introduces: new visa category."])
+    diff = make_diff("ADDED", "+new visa category details\n")
+
+    result = summarize_page_diff(diff)
+
+    assert "introduces" in result.bullets[0]
+    call_kwargs = patch_chain.invoke.call_args[0][0]
+    assert call_kwargs["change_type"] == "ADDED"
+    assert "introduces" in call_kwargs["instructions"]
+
+
+def test_summarize_removed_uses_removed_instructions(patch_chain):
+    patch_chain.invoke.return_value = mock_summary(["This no longer applies: old requirement."])
+    diff = make_diff("REMOVED", "-old requirement details\n")
+
+    result = summarize_page_diff(diff)
+
+    assert "no longer" in result.bullets[0]
+    call_kwargs = patch_chain.invoke.call_args[0][0]
+    assert call_kwargs["change_type"] == "REMOVED"
+    assert "no longer" in call_kwargs["instructions"]
+
+
+def test_summarize_batch_returns_paired_results(patch_chain):
+    patch_chain.invoke.side_effect = [
+        mock_summary(["Before: 180 days. Now: 120 days."]),
+        mock_summary(["This page introduces: new sponsorship rules."]),
+    ]
+    diffs = [make_diff("CHANGED"), make_diff("ADDED")]
+
+    results = summarize_page_diffs(diffs)
+
+    assert len(results) == 2
+    assert results[0][0] is diffs[0]
+    assert results[1][0] is diffs[1]
+    assert results[0][1].bullets == ["Before: 180 days. Now: 120 days."]
+    assert results[1][1].bullets == ["This page introduces: new sponsorship rules."]
+
+
+def test_summarize_passes_url_to_llm(patch_chain):
+    patch_chain.invoke.return_value = mock_summary(["Before: A. Now: B."])
+    diff = PageDiff(
+        url="https://ind.nl/en/specific-page",
+        change_type="CHANGED",
+        unified_diff="-old\n+new\n",
+        content="new",
+    )
+
+    summarize_page_diff(diff)
+
+    assert patch_chain.invoke.call_args[0][0]["url"] == "https://ind.nl/en/specific-page"

--- a/data_pipeline/tests/test_ind_summarize_integration.py
+++ b/data_pipeline/tests/test_ind_summarize_integration.py
@@ -1,0 +1,73 @@
+"""
+Integration test: summarize a real IND page diff using the LLM.
+
+Uses the same fixture diffs as test_ind_diff.py. The modified fixture changes
+two pages with concrete numeric values — the test asserts the LLM picked up
+the right numbers, not just that it returned something.
+
+Run with:
+    uv run --package data-pipeline pytest -m integration data_pipeline/tests/test_ind_summarize_integration.py -v
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from diff_detector.diff import run_diff
+from diff_detector.summarize import summarize_page_diff
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+SPONSOR_URL = "https://ind.nl/en/residence-permits/work/apply-for-recognition-as-sponsor"
+RESEARCHER_URL = "https://ind.nl/en/residence-permits/work/directive-eu-2016801-short-term-mobility-of-researchers"
+
+
+def _load_fixture(name: str) -> dict[str, str]:
+    return {
+        r["url"]: r["content"]
+        for r in json.loads((FIXTURES / name).read_text())
+        if r.get("content")
+    }
+
+
+@pytest.fixture(scope="module")
+def ind_diffs():
+    baseline = _load_fixture("ind_snapshot_baseline.json")
+    modified = _load_fixture("ind_snapshot_modified.json")
+    return {d.url: d for d in run_diff(baseline, modified)}
+
+
+@pytest.mark.integration
+def test_summarize_sponsor_page_catches_point_and_penalty_changes(ind_diffs):
+    """The sponsor page changed the RVO point threshold (50→65) and the
+    penalty lookback window (4→3 years). The summary must mention both."""
+    diff = ind_diffs[SPONSOR_URL]
+    print(f"\n--- DIFF ---\n{diff.unified_diff}")
+
+    summary = summarize_page_diff(diff)
+    print(f"\n--- SUMMARY ---")
+    for bullet in summary.bullets:
+        print(f"  • {bullet}")
+
+    bullets_text = " ".join(summary.bullets).lower()
+    assert "65" in bullets_text, "Expected the new 65-point threshold to appear"
+    assert "50" in bullets_text, "Expected the old 50-point threshold to appear"
+    assert "3" in bullets_text, "Expected the new 3-year penalty window to appear"
+    assert "4" in bullets_text, "Expected the old 4-year penalty window to appear"
+
+
+@pytest.mark.integration
+def test_summarize_researcher_page_catches_day_window_change(ind_diffs):
+    """The researcher mobility page changed the short-term window (180→120 days)
+    in multiple places. The summary must mention both values."""
+    diff = ind_diffs[RESEARCHER_URL]
+    print(f"\n--- DIFF ---\n{diff.unified_diff}")
+
+    summary = summarize_page_diff(diff)
+    print(f"\n--- SUMMARY ---")
+    for bullet in summary.bullets:
+        print(f"  • {bullet}")
+
+    bullets_text = " ".join(summary.bullets).lower()
+    assert "120" in bullets_text, "Expected the new 120-day window to appear"
+    assert "180" in bullets_text, "Expected the old 180-day window to appear"


### PR DESCRIPTION
## IND Website Change Detector — Summarize, Classify & Notify

Implements the core pipeline for detecting changes to the IND (Dutch Immigration and Naturalisation Service) website and notifying relevant users by email.

### How to test

**Visually inspect the rendered email:**
```bash
uv run --package data-pipeline pytest data_pipeline/tests/test_ind_notify.py -v -s -k preview
```
This prints both the plain text and HTML to the terminal. Paste the HTML into a browser or [htmlpreview.github.io](https://htmlpreview.github.io) to see the styled output.


Unit tests (no LLM, fast):
```bash
uv run --package data-pipeline pytest data_pipeline/tests/test_ind_notify.py data_pipeline/tests/test_ind_summarize.py data_pipeline/tests/test_diff.py -v
```

Integration tests (real LLM calls, uses fixture diffs):
```bash
uv run --package data-pipeline pytest -m integration data_pipeline/tests/test_ind_summarize_integration.py data_pipeline/tests/test_ind_classify_integration.py -v -s
```

---


### What's in this PR

**`diff_detector/diff.py`** (refactored)
- `PageDiff` dataclass — structured diff output with `url`, `change_type`, `unified_diff`, and `content`
- `unified_diff` is populated for all change types: real unified diff for CHANGED, `+` lines for ADDED, `-` lines for REMOVED — so the LLM always reads from the same field
- `render_report(diffs, total_pages)` — human-readable summary of all changes

**`lib/user_attributes.py`** (new)
- Single source of truth for all user profile attributes and their allowed values, including boolean attributes (`has_fiscal_partner`, `age_bracket_under_30`, `prior_nl_residency`)

**`diff_detector/summarize.py`** (new)
- LLM summarizer (`gpt-4o-mini`) that reads each page diff and returns a list of bullet points — one per distinct semantic change
- Per-change-type framing instructions so the model understands whether something was added, removed, or modified

**`diff_detector/classify.py`** (new)
- LLM classifier that takes a `PageDiffSummary` and outputs a `RelevanceMap` — a dict of `attribute → value → [bullets]`
- Tells us which user profile segments are affected by each change (e.g. "Highly Skilled Migrant", "Non-EU national")
- Uses `method="function_calling"` instead of strict structured output because dynamic dict keys aren't supported by OpenAI strict mode

**`diff_detector/notify.py`** (new)
- `get_user_bullets(user, relevance_map)` — filters the relevance map down to only what's relevant for a specific user, deduplicating bullets that appear in multiple slots
- `render_ind_diff_email(user, relevance_map)` — returns `(subject, plain_text, html)` or `None` if nothing is relevant to that user
- Sending and user querying are **not yet wired up** — pending the `ind_diff_email_enabled` DB migration

---


### What's not in this PR
- Supabase user querying (`ind_diff_email_enabled` column — separate migration branch)
- Resend sending
- Scheduler / weekly job orchestration
- DB upsert of changed pages back to `sources` table
